### PR TITLE
Update url used for fetching token images from trust wallet

### DIFF
--- a/src/jobs/get-missing-token-images.js
+++ b/src/jobs/get-missing-token-images.js
@@ -14,7 +14,7 @@ const getMissingTokenImages = async () => {
   logger.pending('fetching images from Trust Wallet repository');
 
   const response = await axios.get(
-    'https://api.github.com/repos/TrustWallet/tokens/contents/images',
+    'https://api.github.com/repos/TrustWallet/tokens/contents/tokens',
   );
 
   if (!_.isArray(response.data)) {


### PR DESCRIPTION
Location of images in the TrustWallet repo has changed so I've updated the URL.