### PR TITLE
Introduce job for caching stats

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -40,6 +40,7 @@ module.exports = {
     default: 10,
   },
   pollingIntervals: {
+    cacheStats: ms('1 minute'),
     default: ms('5 seconds'),
     getMissingTokenImages: ms('1 minute'),
     getMissingTokens: ms('1 minute'),

--- a/src/jobs/cache-stats.js
+++ b/src/jobs/cache-stats.js
@@ -1,0 +1,42 @@
+const moment = require('moment');
+const signale = require('signale');
+
+const CacheEntry = require('../model/cache-entry');
+const getNetworkStats = require('../stats/get-network-stats');
+const getRelayerStats = require('../stats/get-relayer-stats');
+
+const logger = signale.scope('cache stats');
+
+const cacheStats = async () => {
+  const dateFrom = moment()
+    .subtract(1, 'days')
+    .toDate();
+
+  const dateTo = moment().toDate();
+
+  logger.time('compute network stats');
+  const networkStats = await getNetworkStats(dateFrom, dateTo);
+  logger.timeEnd('compute network stats');
+
+  await CacheEntry.updateOne(
+    { key: 'networkStats.24h' },
+    { $set: { data: networkStats, key: 'networkStats.24h' } },
+    { upsert: true },
+  );
+
+  logger.success('cached 24h network stats');
+
+  logger.time('compute relayer stats');
+  const relayerStats = await getRelayerStats();
+  logger.time('compute relayer stats');
+
+  await CacheEntry.updateOne(
+    { key: 'relayerStats.24h' },
+    { $set: { data: relayerStats } },
+    { upsert: true },
+  );
+
+  logger.success('cached 24h relayer stats');
+};
+
+module.exports = cacheStats;

--- a/src/jobs/index.js
+++ b/src/jobs/index.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 
+const cacheStats = require('./cache-stats');
 const createFills = require('./create-fills');
 const getMissingTokenImages = require('./get-missing-token-images');
 const getMissingTokens = require('./get-missing-tokens');
@@ -13,6 +14,7 @@ const updateTokenPrices = require('./update-token-prices');
 const updateTokenStats = require('./update-token-stats');
 
 const jobFns = {
+  cacheStats,
   createFills,
   getMissingTokenImages,
   getMissingTokens,

--- a/src/model/cache-entry.js
+++ b/src/model/cache-entry.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const schema = Schema({
+  data: Schema.Types.Mixed,
+  key: { type: String, index: true },
+});
+
+const Model = mongoose.model('CacheEntry', schema);
+
+module.exports = Model;

--- a/src/stats/get-network-stats.js
+++ b/src/stats/get-network-stats.js
@@ -1,0 +1,46 @@
+const _ = require('lodash');
+
+const { ZRX_TOKEN_ADDRESS } = require('../constants');
+const { getToken } = require('../tokens/token-cache');
+const Fill = require('../model/fill');
+const formatTokenAmount = require('../tokens/format-token-amount');
+
+const getNetworkStats = async (dateFrom, dateTo) => {
+  const metrics = await Fill.aggregate([
+    {
+      $match: {
+        date: { $gte: new Date(dateFrom), $lte: new Date(dateTo) },
+      },
+    },
+    {
+      $group: {
+        _id: null,
+        localisedMakerFees: { $sum: `$conversions.USD.makerFee` },
+        localisedTakerFees: { $sum: `$conversions.USD.takerFee` },
+        fills: { $sum: 1 },
+        makerFee: { $sum: '$makerFee' },
+        takerFee: { $sum: '$takerFee' },
+        volume: { $sum: `$conversions.USD.amount` },
+      },
+    },
+  ]);
+
+  const zrxToken = await getToken(ZRX_TOKEN_ADDRESS);
+  const metric = metrics[0];
+
+  return {
+    fees: {
+      USD:
+        _.get(metric, 'localisedMakerFees', 0) +
+        _.get(metric, 'localisedTakerFees', 0),
+      ZRX: formatTokenAmount(
+        _.get(metric, 'makerFee', 0) + _.get(metric, 'takerFee', 0),
+        zrxToken,
+      ),
+    },
+    fills: _.get(metric, 'fills', 0),
+    volume: _.get(metric, 'volume', 0),
+  };
+};
+
+module.exports = getNetworkStats;

--- a/src/stats/get-relayer-stats.js
+++ b/src/stats/get-relayer-stats.js
@@ -1,0 +1,28 @@
+const _ = require('lodash');
+const BigNumber = require('bignumber.js');
+
+const getRelayersStats = require('./get-relayers-stats');
+
+const getRelayerStats = async (dateFrom, dateTo) => {
+  const relayerStats = await getRelayersStats(dateFrom, dateTo);
+  const stats = _.reduce(
+    relayerStats,
+    (acc, stat) => ({
+      fees: {
+        USD: acc.fees.USD + stat.fees.USD,
+        ZRX: acc.fees.ZRX.plus(stat.fees.ZRX.toString()),
+      },
+      trades: acc.trades + stat.trades,
+      tradeVolume: acc.tradeVolume + stat.volume,
+    }),
+    {
+      fees: { USD: 0, ZRX: new BigNumber(0) },
+      trades: 0,
+      tradeVolume: 0,
+    },
+  );
+
+  return stats;
+};
+
+module.exports = getRelayerStats;

--- a/src/stats/get-relayers-stats.js
+++ b/src/stats/get-relayers-stats.js
@@ -1,0 +1,81 @@
+const _ = require('lodash');
+
+const { ZRX_TOKEN_ADDRESS } = require('../constants');
+const { getToken } = require('../tokens/token-cache');
+const Fill = require('../model/fill');
+const formatTokenAmount = require('../tokens/format-token-amount');
+const getAllRelayers = require('../relayers/get-all-relayers');
+
+const getRelayersStats = async (dateFrom, dateTo) => {
+  const metrics = await Fill.aggregate([
+    {
+      $match: {
+        date: { $gte: new Date(dateFrom), $lte: new Date(dateTo) },
+        relayerId: { $ne: null },
+      },
+    },
+    {
+      $group: {
+        _id: {
+          relayerId: `$relayerId`,
+        },
+        localisedMakerFees: { $sum: `$conversions.USD.makerFee` },
+        localisedTakerFees: { $sum: `$conversions.USD.takerFee` },
+        makerFee: { $sum: '$makerFee' },
+        takerFee: { $sum: '$takerFee' },
+        trades: { $sum: 1 },
+        volume: { $sum: `$conversions.USD.amount` },
+      },
+    },
+  ]);
+
+  const relayers = getAllRelayers();
+  const zrxToken = getToken(ZRX_TOKEN_ADDRESS);
+
+  const stats = _.map(relayers, relayer => {
+    const metric = _.find(metrics, { _id: { relayerId: relayer.lookupId } });
+
+    if (_.isUndefined(metric)) {
+      return {
+        fees: { USD: 0, ZRX: 0 },
+        relayerId: relayer.lookupId,
+        trades: 0,
+        volume: 0,
+      };
+    }
+
+    const {
+      localisedMakerFees,
+      localisedTakerFees,
+      makerFee,
+      takerFee,
+      trades,
+      volume,
+    } = metric;
+
+    const stat = {
+      fees: {
+        USD: localisedMakerFees + localisedTakerFees,
+        ZRX: formatTokenAmount(makerFee + takerFee, zrxToken),
+      },
+      relayerId: relayer.lookupId,
+      trades,
+      volume,
+    };
+
+    if (relayer.orderMatcher) {
+      return {
+        fees: stat.fees,
+        relayerId: relayer.lookupId,
+        trades: Math.ceil(stat.trades / 2),
+        volume: stat.volume / 2,
+      };
+    }
+
+    return stat;
+  });
+
+  return stats;
+};
+
+module.exports = getRelayersStats;


### PR DESCRIPTION
# Description

This PR introduces a job for caching stats because performing this work in the API was causing instability. A rework of the metrics caching may help to simplify this in the future.