### PR TITLE
Optimise mongodb calls when computing relayer metrics

### DIFF
--- a/src/jobs/update-relayer-metrics.js
+++ b/src/jobs/update-relayer-metrics.js
@@ -1,24 +1,15 @@
 const _ = require('lodash');
-const bluebird = require('bluebird');
 const moment = require('moment');
 const signale = require('signale');
 
 const computeRelayerMetrics = require('../metrics/compute-relayer-metrics');
 const getDatesForMetricsJob = require('../metrics/get-dates-for-metrics-job');
+const MetricsJobMetadata = require('../model/metrics-job-metadata');
 const RelayerMetric = require('../model/relayer-metric');
-const updateMetricsJobMetadata = require('../metrics/update-metrics-job-metadata');
 const withTransaction = require('../util/with-transaction');
 
 const logger = signale.scope('update relayer metrics');
 
-/*
-  This job is responsible for updating the most stale relayer metrics (based on
-  a last updated date), as well as relayer metrics for today. This ensures that
-  todays metrics are updated regularly, and any changes from past days 
-  (e.g. a newly identified) relayer are also accounted for.
-
-  TODO: Set a cut off date (e.g. more than 30 days) for when previous metrics get updated.
-*/
 const updateRelayerMetrics = async () => {
   const dates = await getDatesForMetricsJob('relayer');
 
@@ -39,23 +30,33 @@ const updateRelayerMetrics = async () => {
 
   logger.time('persist metrics');
   await withTransaction(async session => {
-    await bluebird.mapSeries(metrics, async metric => {
-      await RelayerMetric.updateOne(
-        { date: metric.date, relayerId: metric.relayerId },
-        { $set: metric },
-        { session, upsert: true },
-      );
-
-      await updateMetricsJobMetadata(
-        'relayer',
-        metric.date,
-        {
-          lastUpdated: Date.now(),
-          timeTaken: null, // TODO: Calculate and store time taken
+    await RelayerMetric.bulkWrite(
+      metrics.map(metric => ({
+        updateOne: {
+          filter: { date: metric.date, relayerId: metric.relayerId },
+          update: { $set: metric },
+          upsert: true,
         },
-        session,
-      );
-    });
+      })),
+      { session },
+    );
+
+    await MetricsJobMetadata.bulkWrite(
+      dates.map(date => ({
+        updateOne: {
+          filter: { date, metricType: 'relayer' },
+          update: {
+            $set: {
+              date,
+              metricType: 'relayer',
+              lastUpdated: Date.now(),
+            },
+          },
+          upsert: true,
+        },
+      })),
+      { session },
+    );
   });
   logger.timeEnd('persist metrics');
 


### PR DESCRIPTION
# What does this PR do?

This PR updates some MongoDB persistence calls by using the bulkWrite API instead of individual calls. This pattern will be copied when building out the token metrics job.