### PR TITLE
Use pricing status in prices job

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -26,6 +26,10 @@ module.exports = {
     MAKER: 0,
     TAKER: 1,
   },
+  FILL_PRICING_STATUS: {
+    PRICED: 0,
+    UNPRICEABLE: 1,
+  },
   FILL_STATUS: {
     FAILED: 2,
     PENDING: 0,

--- a/src/jobs/derive-fill-prices/check-is-fill-unpriceable.js
+++ b/src/jobs/derive-fill-prices/check-is-fill-unpriceable.js
@@ -1,0 +1,5 @@
+const checkCanPriceFill = () => {
+  return false; // TODO: Implement support for multi-asset fills
+};
+
+module.exports = checkCanPriceFill;

--- a/src/jobs/derive-fill-prices/fetch-unpriced-fills.js
+++ b/src/jobs/derive-fill-prices/fetch-unpriced-fills.js
@@ -1,0 +1,15 @@
+const Fill = require('../../model/fill');
+
+const fetchUnpricedFills = async batchSize => {
+  const fills = await Fill.find({
+    hasValue: true,
+    pricingStatus: null,
+    assets: {
+      $not: { $elemMatch: { tokenResolved: false } },
+    },
+  }).limit(batchSize);
+
+  return fills;
+};
+
+module.exports = fetchUnpricedFills;

--- a/src/jobs/derive-fill-prices/index.js
+++ b/src/jobs/derive-fill-prices/index.js
@@ -1,106 +1,32 @@
-const _ = require('lodash');
 const bluebird = require('bluebird');
 const signale = require('signale');
 
-const Fill = require('../../model/fill');
-const getPrices = require('./get-prices-for-fill');
-const Token = require('../../model/token');
-const withTransaction = require('../../util/with-transaction');
+const checkIsFillUnpriceable = require('./check-is-fill-unpriceable');
+const fetchUnpricedFills = require('./fetch-unpriced-fills');
+const markFillAsUnpriceable = require('./mark-fill-as-unpriceable');
+const priceFill = require('./price-fill');
 
 const logger = signale.scope('derive fill prices');
 
-// TODO: Rewrite this job to support multi-asset fills
 const deriveFillPrices = async ({ batchSize }) => {
-  logger.time('fetch batch of fills');
-  const fills = await Fill.find({
-    hasValue: true,
-    'prices.saved': false,
-    assets: {
-      $not: { $elemMatch: { tokenResolved: false } },
-    },
-  }).limit(batchSize);
-  logger.timeEnd('fetch batch of fills');
+  const fills = await fetchUnpricedFills(batchSize);
 
-  logger.info(`found ${fills.length} fills which need their prices derived`);
+  logger.info(`found ${fills.length} unpriced fills`);
 
   if (fills.length === 0) {
     return;
   }
 
   await bluebird.mapSeries(fills, async fill => {
-    const pricedAssets = getPrices(fill);
+    if (checkIsFillUnpriceable(fill)) {
+      await markFillAsUnpriceable(fill._id);
 
-    if (pricedAssets === null) {
-      logger.warn(`unable to derive prices for fill ${fill._id}`);
-      return;
+      logger.info(`marked fill ${fill._id} as unpriceable`);
+    } else {
+      await priceFill(fill);
+
+      logger.success(`priced fill ${fill._id}`);
     }
-
-    await withTransaction(async session => {
-      // Set the price of all assets belonging to the fill
-      await bluebird.mapSeries(pricedAssets, async pricedAsset => {
-        await Fill.updateOne(
-          { _id: fill._id },
-          {
-            $set: {
-              'assets.$[asset].price': pricedAsset.price,
-            },
-          },
-          {
-            arrayFilters: [{ 'asset.tokenAddress': pricedAsset.tokenAddress }],
-            session,
-          },
-        );
-
-        logger.debug(
-          `set price of ${pricedAsset.tokenAddress} to ${pricedAsset.price.USD} on ${fill._id}`,
-        );
-      });
-
-      // Flag the fill as having its prices saved
-      await Fill.updateOne(
-        { _id: fill._id },
-        { $set: { 'prices.saved': true } },
-        { session },
-      );
-
-      // If this trade is verified (associated with a known relayer) then update
-      // token prices where applicable.
-      if (_.isNumber(fill.relayerId)) {
-        await bluebird.mapSeries(
-          pricedAssets,
-          async ({ price, tokenAddress }) => {
-            const result = await Token.updateOne(
-              {
-                address: tokenAddress,
-                $or: [
-                  {
-                    'price.lastTrade.date': null,
-                  },
-                  {
-                    'price.lastTrade.date': { $lt: fill.date },
-                  },
-                ],
-              },
-              {
-                $set: {
-                  price: {
-                    lastTrade: { id: fill.id, date: fill.date },
-                    lastPrice: price.USD,
-                  },
-                },
-              },
-              { session },
-            );
-
-            if (result.nModified > 0) {
-              logger.debug(`updated price of token ${tokenAddress}`);
-            }
-          },
-        );
-      }
-    });
-
-    logger.success(`derived prices for fill ${fill._id}`);
   });
 };
 

--- a/src/jobs/derive-fill-prices/mark-fill-as-unpriceable.js
+++ b/src/jobs/derive-fill-prices/mark-fill-as-unpriceable.js
@@ -1,0 +1,11 @@
+const { FILL_PRICING_STATUS } = require('../../constants');
+const Fill = require('../../model/fill');
+
+const markFillAsUnpriceable = async fillId => {
+  await Fill.updateOne(
+    { _id: fillId },
+    { $set: { pricingStatus: FILL_PRICING_STATUS.UNPRICEABLE } },
+  );
+};
+
+module.exports = markFillAsUnpriceable;

--- a/src/jobs/derive-fill-prices/persist-asset-prices.js
+++ b/src/jobs/derive-fill-prices/persist-asset-prices.js
@@ -1,0 +1,26 @@
+const signale = require('signale');
+
+const { FILL_PRICING_STATUS } = require('../../constants');
+
+const logger = signale.scope('persist asset prices');
+
+const persistAssetPrices = async (tokenPrices, fill, session) => {
+  fill.assets.forEach(asset => {
+    const tokenPrice = tokenPrices.find(
+      ({ tokenAddress }) => tokenAddress === asset.tokenAddress,
+    );
+
+    if (tokenPrice !== undefined) {
+      asset.set({ 'price.USD': tokenPrice.price.USD });
+      logger.debug(
+        `set price of ${tokenPrice.tokenAddress} to ${tokenPrice.price.USD} on ${fill._id}`,
+      );
+    }
+  });
+
+  fill.set('pricingStatus', FILL_PRICING_STATUS.PRICED);
+
+  await fill.save({ session });
+};
+
+module.exports = persistAssetPrices;

--- a/src/jobs/derive-fill-prices/persist-token-prices.js
+++ b/src/jobs/derive-fill-prices/persist-token-prices.js
@@ -1,0 +1,41 @@
+const bluebird = require('bluebird');
+const signale = require('signale');
+
+const Token = require('../../model/token');
+
+const logger = signale.scope('set token prices');
+
+const persistTokenPrices = async (tokenPrices, fill, session) => {
+  // Updates must be done in sequence due to WriteConflict errors arising from
+  // parallel commands attached to a transaction session.
+  await bluebird.mapSeries(tokenPrices, async ({ price, tokenAddress }) => {
+    const result = await Token.updateOne(
+      {
+        address: tokenAddress,
+        $or: [
+          {
+            'price.lastTrade.date': null,
+          },
+          {
+            'price.lastTrade.date': { $lt: fill.date },
+          },
+        ],
+      },
+      {
+        $set: {
+          price: {
+            lastTrade: { id: fill.id, date: fill.date },
+            lastPrice: price.USD,
+          },
+        },
+      },
+      { session },
+    );
+
+    if (result.nModified > 0) {
+      logger.debug(`updated price of token ${tokenAddress}`);
+    }
+  });
+};
+
+module.exports = persistTokenPrices;

--- a/src/jobs/derive-fill-prices/price-fill.js
+++ b/src/jobs/derive-fill-prices/price-fill.js
@@ -1,0 +1,24 @@
+const getPricesForFill = require('./get-prices-for-fill');
+const persistAssetPrices = require('./persist-asset-prices');
+const persistTokenPrices = require('./persist-token-prices');
+const withTransaction = require('../../util/with-transaction');
+
+const priceFill = async fill => {
+  const tokenPrices = getPricesForFill(fill);
+
+  if (tokenPrices === null) {
+    throw new Error(`Unable to derive prices of fill ${fill._id}`);
+  }
+
+  await withTransaction(async session => {
+    await persistAssetPrices(tokenPrices, fill, session);
+
+    if (fill.relayerId !== undefined && fill.relayerId !== null) {
+      // If this trade is verified (associated with a known relayer) then update
+      // token prices where applicable.
+      await persistTokenPrices(tokenPrices, fill, session);
+    }
+  });
+};
+
+module.exports = priceFill;

--- a/src/model/fill.js
+++ b/src/model/fill.js
@@ -35,9 +35,7 @@ const schema = Schema({
   maker: String,
   makerFee: Number,
   orderHash: String,
-  prices: {
-    saved: { default: false, type: Boolean },
-  },
+  pricingStatus: Number,
   protocolVersion: Number,
   rates: {
     data: Schema.Types.Mixed,
@@ -86,7 +84,7 @@ schema.index({ hasValue: 1, 'assets.tokenAddress': 1, immeasurable: -1 });
 // Used by derive-fill-prices job
 schema.index({
   hasValue: -1,
-  'prices.saved': 1,
+  pricingStatus: 1,
   'assets.tokenResolved': -1,
 });
 


### PR DESCRIPTION
# Description

This PR lays the groundwork for supporting multi-asset fills in the pricing job by introducing a pricing status field which replaces the old 'prices.saved' field. This field can be set to UNPRICEABLE which allows us to ignore multi-asset fills which cannot be priced.