### PR TITLE
Change Ethfinex to DeversiFi

### DIFF
--- a/src/relayers/__snapshots__/get-all-relayers.test.js.snap
+++ b/src/relayers/__snapshots__/get-all-relayers.test.js.snap
@@ -48,6 +48,17 @@ Object {
     ],
     "url": "https://ddex.io",
   },
+  "deversifi": Object {
+    "feeRecipients": Array [
+      "0x61b9898c9b60a159fc91ae8026563cd226b7a0c1",
+    ],
+    "id": "deversifi",
+    "imageUrl": "https://0xtracker.com/assets/logos/deversifi.png",
+    "lookupId": 21,
+    "name": "DeversiFi",
+    "slug": "deversifi",
+    "url": "https://www.deversifi.com/",
+  },
   "emoon": Object {
     "feeRecipients": Array [
       "0xb0d7398d779ee9ffc727d2d5b045a5b441da8233",
@@ -81,17 +92,6 @@ Object {
     "name": "EtherBlockchain.io",
     "slug": "ether-blockchain",
     "url": "https://www.etherblockchain.io/",
-  },
-  "ethfinex": Object {
-    "feeRecipients": Array [
-      "0x61b9898c9b60a159fc91ae8026563cd226b7a0c1",
-    ],
-    "id": "ethfinex",
-    "imageUrl": "https://0xtracker.com/assets/logos/ethfinex.png",
-    "lookupId": 21,
-    "name": "Ethfinex",
-    "slug": "ethfinex",
-    "url": "https://www.ethfinex.com/",
   },
   "fordex": Object {
     "id": "fordex",

--- a/src/relayers/relayer-registry.js
+++ b/src/relayers/relayer-registry.js
@@ -177,13 +177,13 @@ module.exports = {
     takerAddresses: ['0x853da5cecc1ea601ab978c2001565a0377a7dca6'],
     url: 'https://www.fordex.co',
   },
-  ethfinex: {
-    imageUrl: 'https://0xtracker.com/assets/logos/ethfinex.png',
+  deversifi: {
+    imageUrl: 'https://0xtracker.com/assets/logos/deversifi.png',
     lookupId: 21,
-    name: 'Ethfinex',
-    slug: 'ethfinex',
+    name: 'DeversiFi',
+    slug: 'deversifi',
     feeRecipients: ['0x61b9898c9b60a159fc91ae8026563cd226b7a0c1'],
-    url: 'https://www.ethfinex.com/',
+    url: 'https://www.deversifi.com/',
   },
   etherBlockchain: {
     imageUrl: 'https://0xtracker.com/assets/logos/ether-blockchain.png',


### PR DESCRIPTION
# Description

This PR changes Ethfinex to DeversiFi following their [recent rebranding](https://blog.ethfinex.com/introducing-deversifi/).