### PR TITLE
Ensure v3 events are ignored in create-fills job

### DIFF
--- a/src/jobs/create-fills/index.js
+++ b/src/jobs/create-fills/index.js
@@ -13,9 +13,12 @@ const persistFill = require('./persist-fill');
 
 const logger = signale.scope('create fills');
 
+const SUPPORTED_VERSIONS = [1, 2];
+
 const createFills = async ({ batchSize }) => {
   const events = await Event.find({
     fillCreated: { $in: [false, null] },
+    protocolVersion: { $in: SUPPORTED_VERSIONS },
   }).limit(batchSize);
 
   logger.info(`found ${events.length} events without associated fills`);


### PR DESCRIPTION
# Description

This PR updates the create-fills job to ensure it only processes events from supported protocol versions (i.e. 1 and 2).

# Related Issues
https://github.com/0xTracker/0x-tracker-worker/issues/314