### PR TITLE
Refactor web3 client to use provider utils

### DIFF
--- a/src/util/ethereum/web3.js
+++ b/src/util/ethereum/web3.js
@@ -1,5 +1,6 @@
 const { RPCSubprovider, Web3ProviderEngine } = require('@0x/subproviders');
 const { Web3Wrapper } = require('@0x/web3-wrapper');
+const { providerUtils } = require('@0x/utils');
 
 let wrapper;
 
@@ -7,7 +8,7 @@ const configure = ({ endpoint }) => {
   const providerEngine = new Web3ProviderEngine();
 
   providerEngine.addProvider(new RPCSubprovider(endpoint));
-  providerEngine.start();
+  providerUtils.startProviderEngine(providerEngine);
 
   wrapper = new Web3Wrapper(providerEngine);
 };


### PR DESCRIPTION
# Description

This PR refactors the web3 client to use `providerUtils.startProviderEngine` rather than `providerEngine.start`. This will massively reduce the number of calls being made to the web3 endpoint because `providerEngine.start` invokes a polling operation which polls regularly for the latest block.