### PR TITLE
Ensure only v3 fills are used in convert-fees job

### DIFF
--- a/src/jobs/convert-fees.js
+++ b/src/jobs/convert-fees.js
@@ -9,6 +9,8 @@ const getConversionRate = require('../rates/get-conversion-rate');
 
 const logger = signale.scope('convert fees');
 
+const SUPPORTED_VERSIONS = [1, 2];
+
 const convertAmount = (amount, conversionRate) => {
   if (amount === 0) {
     return 0;
@@ -28,6 +30,7 @@ const convertFees = async ({ batchSize }) => {
       { 'conversions.USD.makerFee': null },
       { 'conversions.USD.takerFee': null },
     ],
+    protocolVersion: { $in: SUPPORTED_VERSIONS },
   })
     .limit(batchSize)
     .lean();


### PR DESCRIPTION
# Description

This PR updates the convert-fees job to ensure it only processes v1 and v2 fills. This is to ensure the job doesn't fall over when v3 fills are introduced due to their new fees data structure.

# Related Issues
https://github.com/0xTracker/0x-tracker-worker/issues/316