### PR TITLE
Add taker address for star bit

### DIFF
--- a/src/relayers/__snapshots__/get-all-relayers.test.js.snap
+++ b/src/relayers/__snapshots__/get-all-relayers.test.js.snap
@@ -240,6 +240,9 @@ Object {
     "name": "STAR BIT",
     "orderMatcher": true,
     "slug": "star-bit",
+    "takerAddresses": Array [
+      "0x0681e844593a051e2882ec897ecd5444efe19ff2",
+    ],
     "url": "https://www.starbitex.com",
   },
   "theOcean": Object {

--- a/src/relayers/relayer-registry.js
+++ b/src/relayers/relayer-registry.js
@@ -81,6 +81,7 @@ module.exports = {
     name: 'STAR BIT',
     orderMatcher: true,
     slug: 'star-bit',
+    takerAddresses: ['0x0681e844593a051e2882ec897ecd5444efe19ff2'],
     url: 'https://www.starbitex.com',
   },
   tokenJar: {


### PR DESCRIPTION
# Description

This PR adds the taker address for star bit exchange so that it can be correctly identified as a relayer by the traders endpoints.