### PR TITLE
Fix the fetching of fill dates

### DIFF
--- a/src/jobs/create-fills/create-fill.js
+++ b/src/jobs/create-fills/create-fill.js
@@ -19,7 +19,7 @@ const createFill = async event => {
   const { data, protocolVersion } = event;
   const { args, blockHash, blockNumber, logIndex, transactionHash } = data;
 
-  const block = await getBlockOrThrow();
+  const block = await getBlockOrThrow(blockHash);
   const date = new Date(block.timestamp * 1000);
 
   const {


### PR DESCRIPTION
This PR fixes a bug which caused fill dates to be set to the date of processing rather than the date of their corresponding block. A script is being run against the production data set to ensure any incorrect dates are set to their correct values.

The bug was introduced on 25th October 2019 so any fill since then may have been affected.