### PR TITLE
Increase timeout for deployments

### DIFF
--- a/.ebextensions/01-increase-timeout.config
+++ b/.ebextensions/01-increase-timeout.config
@@ -1,0 +1,4 @@
+option_settings:
+    - namespace: aws:elasticbeanstalk:command
+      option_name: Timeout
+      value: 1800

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ deploy:
   env: $AWS_DEPLOY_ENV
   bucket: $AWS_DEPLOY_BUCKET_NAME
   edge: true
+  cleanup: false
   on:
     branch: master


### PR DESCRIPTION
This PR increases the timeout for elastic beanstalk deployments until the cause of long-running deployments can be determined.