### PR TITLE
Add support for bridged ERC20 assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,14 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@0x/abi-gen-wrappers": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@0x/abi-gen-wrappers/-/abi-gen-wrappers-4.3.0.tgz",
-      "integrity": "sha512-KnpoHbbqfidECl4hTGOvBaCj1N3LASHcdNO38yOMo1eO4B0H+kuyDVFjN3nbNt7lnXTPJ+DdaQpoDVQwySdEDQ==",
-      "requires": {
-        "@0x/base-contract": "^5.1.0"
-      }
-    },
     "@0x/assert": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@0x/assert/-/assert-2.0.10.tgz",
@@ -25,76 +17,81 @@
       }
     },
     "@0x/base-contract": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@0x/base-contract/-/base-contract-5.1.0.tgz",
-      "integrity": "sha512-0LI967ynPr8CuPJkpxZ0YUQX1ta63pVw8waTy2Yd3+UOdGS8dVDd9V/hvWPZpnviTO3zHxheFCPOnipgmht4Yw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@0x/base-contract/-/base-contract-6.0.2.tgz",
+      "integrity": "sha512-UR6A0KTOqkOLjzaHRy0++WDaWl3Xn6WuaIoAPk9/LD7vnKTCK+NzohCh3pBRbgkkEylng2000jldbDMZkM5FXA==",
       "requires": {
-        "@0x/typescript-typings": "^4.2.2",
-        "@0x/utils": "^4.3.3",
-        "@0x/web3-wrapper": "^6.0.6",
-        "ethereum-types": "^2.1.2",
+        "@0x/assert": "^3.0.2",
+        "@0x/json-schemas": "^5.0.2",
+        "@0x/utils": "^5.1.1",
+        "@0x/web3-wrapper": "^7.0.2",
+        "ethereumjs-account": "^3.0.0",
+        "ethereumjs-blockstream": "^7.0.0",
+        "ethereumjs-util": "^5.1.1",
+        "ethereumjs-vm": "^4.0.0",
         "ethers": "~4.0.4",
-        "lodash": "^4.17.11"
+        "js-sha3": "^0.7.0",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
         "@0x/assert": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/@0x/assert/-/assert-2.0.10.tgz",
-          "integrity": "sha512-tM3j5aZnJGTMr+7OAF61gmflrgEpUkp1LHNsnIx5VnVG+X7JzwV87O44PU9bALVQI1ufYvAUwhIkmK8jbR5Agw==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@0x/assert/-/assert-3.0.2.tgz",
+          "integrity": "sha512-kYRCP/eOoGX3S0zTXskIcy8jA0zxOm20BCDK7EImAQ8HvdmfZr8R6dqUm5UEBLd/JJ6jywR97Y+yCUiteIGg0g==",
           "requires": {
-            "@0x/json-schemas": "^3.0.10",
-            "@0x/typescript-typings": "^4.2.2",
-            "@0x/utils": "^4.3.3",
+            "@0x/json-schemas": "^5.0.2",
+            "@0x/typescript-typings": "^5.0.1",
+            "@0x/utils": "^5.1.1",
             "lodash": "^4.17.11",
             "valid-url": "^1.0.9"
           }
         },
         "@0x/json-schemas": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@0x/json-schemas/-/json-schemas-3.0.10.tgz",
-          "integrity": "sha512-RHYIaxf8C7GO/6VViD8zzRfs1B/i7P5vpCgPk8VR+aVDJXtceF9Nn72KiHeiHU9REUxMWgI3fzhYqTp5/CSbjA==",
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@0x/json-schemas/-/json-schemas-5.0.2.tgz",
+          "integrity": "sha512-2mwC42aWx6tvOCh58pRyYCSrmdajHdmfbDSCsII/8EOWRI6gYYenRMl/edVMnqKw7FH0QLsfWdx5GeP+jNoxDA==",
           "requires": {
-            "@0x/typescript-typings": "^4.2.2",
+            "@0x/typescript-typings": "^5.0.1",
             "@types/node": "*",
             "jsonschema": "^1.2.0",
             "lodash.values": "^4.3.0"
           }
         },
         "@0x/types": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/@0x/types/-/types-2.2.2.tgz",
-          "integrity": "sha512-25F3yjvdWGwiQ99CtFcvyL83PTR2fGQk7J1RzuGbqhu9LTdktjhbQl2/FUzPqbAnGXH47zh1ZZrrMSUVIW9SEA==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@0x/types/-/types-3.1.1.tgz",
+          "integrity": "sha512-+TQmzH+chWeDWpc+Lce3/q4X2UEHFfAwZcWrV7tEQ5EVAJvph7gpKawRW2XRsmHeQDSHBmiiBdSZ8Rc/OAjvlQ==",
           "requires": {
             "@types/node": "*",
-            "bignumber.js": "~8.0.2",
-            "ethereum-types": "^2.1.2"
+            "bignumber.js": "~9.0.0",
+            "ethereum-types": "^3.0.0"
           }
         },
         "@0x/typescript-typings": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/@0x/typescript-typings/-/typescript-typings-4.2.2.tgz",
-          "integrity": "sha512-KKioCi4rLOiC62DF8mqBgN639DdGcJllW7OSPi6gWG4w2JI0mvH6KpRA7wGS9fyIpupjpKTIvz6ktZBaG+DrWg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@0x/typescript-typings/-/typescript-typings-5.0.1.tgz",
+          "integrity": "sha512-zSA39URHkFnL16WD30VMa8wL8va0Khpx9APHffdPWpBOr9SUPdADtae5HO4iNCYvSgo3mrtPlKID2nIqREIHOQ==",
           "requires": {
             "@types/bn.js": "^4.11.0",
             "@types/react": "*",
-            "bignumber.js": "~8.0.2",
-            "ethereum-types": "^2.1.2",
+            "bignumber.js": "~9.0.0",
+            "ethereum-types": "^3.0.0",
             "popper.js": "1.14.3"
           }
         },
         "@0x/utils": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/@0x/utils/-/utils-4.3.3.tgz",
-          "integrity": "sha512-gAFKM8kV5I4A6mpn4+nl9pkstyDiFfQBGz4JBI6ES7s/HRetenVurFN8v1EpEF4N/SOtTzqhGerDUVVtrM3YSQ==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@0x/utils/-/utils-5.1.1.tgz",
+          "integrity": "sha512-DRNKtAqZR0vFA1XdUhBwaIz2qEjWS1xqdvzQl/Dn8OLJH+1sxb+1UmtG6fOlbu7pTLbF+CWoaYf2+pvQfcF//g==",
           "requires": {
-            "@0x/types": "^2.2.2",
-            "@0x/typescript-typings": "^4.2.2",
+            "@0x/types": "^3.1.1",
+            "@0x/typescript-typings": "^5.0.1",
             "@types/node": "*",
             "abortcontroller-polyfill": "^1.1.9",
-            "bignumber.js": "~8.0.2",
+            "bignumber.js": "~9.0.0",
             "chalk": "^2.3.0",
             "detect-node": "2.0.3",
-            "ethereum-types": "^2.1.2",
+            "ethereum-types": "^3.0.0",
             "ethereumjs-util": "^5.1.1",
             "ethers": "~4.0.4",
             "isomorphic-fetch": "2.2.1",
@@ -103,15 +100,15 @@
           }
         },
         "@0x/web3-wrapper": {
-          "version": "6.0.6",
-          "resolved": "https://registry.npmjs.org/@0x/web3-wrapper/-/web3-wrapper-6.0.6.tgz",
-          "integrity": "sha512-cmDHgYnPGNs6ItMw5h+hLe3Cvqaj6V1RY14ZMCc87L7PrwUFQLnrmSfKcsjaqsNDEmbjLf2dNL25DVu6FN/uyw==",
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/@0x/web3-wrapper/-/web3-wrapper-7.0.2.tgz",
+          "integrity": "sha512-kSmrg0E0ZmuNKTKmanxHlRUO5dom8Wr2eDmgG+NZcuWY3EJKIkuxFsz6KRUfoYbVOVT22ZQZazzZIGwoz/LObg==",
           "requires": {
-            "@0x/assert": "^2.0.10",
-            "@0x/json-schemas": "^3.0.10",
-            "@0x/typescript-typings": "^4.2.2",
-            "@0x/utils": "^4.3.3",
-            "ethereum-types": "^2.1.2",
+            "@0x/assert": "^3.0.2",
+            "@0x/json-schemas": "^5.0.2",
+            "@0x/typescript-typings": "^5.0.1",
+            "@0x/utils": "^5.1.1",
+            "ethereum-types": "^3.0.0",
             "ethereumjs-util": "^5.1.1",
             "ethers": "~4.0.4",
             "lodash": "^4.17.11"
@@ -125,10 +122,13 @@
             "color-convert": "^1.9.0"
           }
         },
-        "bignumber.js": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.2.tgz",
-          "integrity": "sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw=="
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
         },
         "chalk": {
           "version": "2.4.2",
@@ -141,12 +141,324 @@
           }
         },
         "ethereum-types": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ethereum-types/-/ethereum-types-2.1.2.tgz",
-          "integrity": "sha512-JsQnroPOsZ81yN75HVzvobosSxjr/59oEdYnydTgnV13Fg9PwS078CtPyBzARXequBl2Hnz4h7f3VF64u8P01A==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ethereum-types/-/ethereum-types-3.0.0.tgz",
+          "integrity": "sha512-jRSsiua+e4/89r7M3mqPcP1M2f3TgXxpVmWysy+7pEg2H4lwEQRWarbYfIpWp81NtxrcMQv5bMK+yR1MN4sDpg==",
           "requires": {
             "@types/node": "*",
-            "bignumber.js": "~8.0.2"
+            "bignumber.js": "~9.0.0"
+          }
+        },
+        "ethereumjs-account": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-3.0.0.tgz",
+          "integrity": "sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==",
+          "requires": {
+            "ethereumjs-util": "^6.0.0",
+            "rlp": "^2.2.1",
+            "safe-buffer": "^5.1.1"
+          },
+          "dependencies": {
+            "@types/bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "ethereumjs-util": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+              "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+              "requires": {
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "0.1.6",
+                "keccak": "^2.0.0",
+                "rlp": "^2.2.3",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "ethereumjs-block": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
+          "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
+          "requires": {
+            "async": "^2.0.1",
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-tx": "^2.1.1",
+            "ethereumjs-util": "^5.0.0",
+            "merkle-patricia-tree": "^2.1.2"
+          }
+        },
+        "ethereumjs-common": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
+          "integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ=="
+        },
+        "ethereumjs-tx": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+          "requires": {
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.0.0"
+          },
+          "dependencies": {
+            "@types/bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "ethereumjs-util": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+              "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+              "requires": {
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "0.1.6",
+                "keccak": "^2.0.0",
+                "rlp": "^2.2.3",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "ethereumjs-vm": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.1.2.tgz",
+          "integrity": "sha512-Zxz/i0u6+74kZ/0UEAbCd2WCSTuS0jPM9LnM9TUGXDbffrkULb1tIBcgHWqYsARGCQJGMDZj5FKDtUJ04Heowg==",
+          "requires": {
+            "async": "^2.1.2",
+            "async-eventemitter": "^0.2.2",
+            "core-js-pure": "^3.0.1",
+            "ethereumjs-account": "^3.0.0",
+            "ethereumjs-block": "^2.2.2",
+            "ethereumjs-blockchain": "^4.0.3",
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-tx": "^2.1.2",
+            "ethereumjs-util": "^6.2.0",
+            "fake-merkle-patricia-tree": "^1.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "merkle-patricia-tree": "^2.3.2",
+            "rustbn.js": "~0.2.0",
+            "safe-buffer": "^5.1.1",
+            "util.promisify": "^1.0.0"
+          },
+          "dependencies": {
+            "@types/bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+              "requires": {
+                "@types/node": "*"
+              }
+            },
+            "ethereumjs-util": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+              "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+              "requires": {
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "0.1.6",
+                "keccak": "^2.0.0",
+                "rlp": "^2.2.3",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "keccak": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+          "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+          "requires": {
+            "bindings": "^1.5.0",
+            "inherits": "^2.0.4",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+            }
+          }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        },
+        "rlp": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+          "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+          "requires": {
+            "bn.js": "^4.11.1"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+        }
+      }
+    },
+    "@0x/contract-addresses": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@0x/contract-addresses/-/contract-addresses-4.1.0.tgz",
+      "integrity": "sha512-scx2Gv6//fBj1Gb3AuqiH6s3qTw1mlcUW6YPp1RnjEGtBPH44cc0PvWmyIeOcCAcEZSVGk8glgTR25QrBAPJnw==",
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "@0x/contract-wrappers": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@0x/contract-wrappers/-/contract-wrappers-13.2.0.tgz",
+      "integrity": "sha512-XvQFdLIleba6CApbvEzFuHwvvBESzerniWecUjf+1imxOZkqRuxOR8XuvWFSp7XZcU37rRgICABmyK3Csu8Cmw==",
+      "requires": {
+        "@0x/assert": "^3.0.2",
+        "@0x/base-contract": "^6.0.2",
+        "@0x/contract-addresses": "^4.1.0",
+        "@0x/json-schemas": "^5.0.2",
+        "@0x/types": "^3.1.1",
+        "@0x/utils": "^5.1.1",
+        "@0x/web3-wrapper": "^7.0.2",
+        "ethereum-types": "^3.0.0",
+        "ethers": "~4.0.4"
+      },
+      "dependencies": {
+        "@0x/assert": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@0x/assert/-/assert-3.0.2.tgz",
+          "integrity": "sha512-kYRCP/eOoGX3S0zTXskIcy8jA0zxOm20BCDK7EImAQ8HvdmfZr8R6dqUm5UEBLd/JJ6jywR97Y+yCUiteIGg0g==",
+          "requires": {
+            "@0x/json-schemas": "^5.0.2",
+            "@0x/typescript-typings": "^5.0.1",
+            "@0x/utils": "^5.1.1",
+            "lodash": "^4.17.11",
+            "valid-url": "^1.0.9"
+          }
+        },
+        "@0x/json-schemas": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@0x/json-schemas/-/json-schemas-5.0.2.tgz",
+          "integrity": "sha512-2mwC42aWx6tvOCh58pRyYCSrmdajHdmfbDSCsII/8EOWRI6gYYenRMl/edVMnqKw7FH0QLsfWdx5GeP+jNoxDA==",
+          "requires": {
+            "@0x/typescript-typings": "^5.0.1",
+            "@types/node": "*",
+            "jsonschema": "^1.2.0",
+            "lodash.values": "^4.3.0"
+          }
+        },
+        "@0x/types": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@0x/types/-/types-3.1.1.tgz",
+          "integrity": "sha512-+TQmzH+chWeDWpc+Lce3/q4X2UEHFfAwZcWrV7tEQ5EVAJvph7gpKawRW2XRsmHeQDSHBmiiBdSZ8Rc/OAjvlQ==",
+          "requires": {
+            "@types/node": "*",
+            "bignumber.js": "~9.0.0",
+            "ethereum-types": "^3.0.0"
+          }
+        },
+        "@0x/typescript-typings": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@0x/typescript-typings/-/typescript-typings-5.0.1.tgz",
+          "integrity": "sha512-zSA39URHkFnL16WD30VMa8wL8va0Khpx9APHffdPWpBOr9SUPdADtae5HO4iNCYvSgo3mrtPlKID2nIqREIHOQ==",
+          "requires": {
+            "@types/bn.js": "^4.11.0",
+            "@types/react": "*",
+            "bignumber.js": "~9.0.0",
+            "ethereum-types": "^3.0.0",
+            "popper.js": "1.14.3"
+          }
+        },
+        "@0x/utils": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@0x/utils/-/utils-5.1.1.tgz",
+          "integrity": "sha512-DRNKtAqZR0vFA1XdUhBwaIz2qEjWS1xqdvzQl/Dn8OLJH+1sxb+1UmtG6fOlbu7pTLbF+CWoaYf2+pvQfcF//g==",
+          "requires": {
+            "@0x/types": "^3.1.1",
+            "@0x/typescript-typings": "^5.0.1",
+            "@types/node": "*",
+            "abortcontroller-polyfill": "^1.1.9",
+            "bignumber.js": "~9.0.0",
+            "chalk": "^2.3.0",
+            "detect-node": "2.0.3",
+            "ethereum-types": "^3.0.0",
+            "ethereumjs-util": "^5.1.1",
+            "ethers": "~4.0.4",
+            "isomorphic-fetch": "2.2.1",
+            "js-sha3": "^0.7.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@0x/web3-wrapper": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/@0x/web3-wrapper/-/web3-wrapper-7.0.2.tgz",
+          "integrity": "sha512-kSmrg0E0ZmuNKTKmanxHlRUO5dom8Wr2eDmgG+NZcuWY3EJKIkuxFsz6KRUfoYbVOVT22ZQZazzZIGwoz/LObg==",
+          "requires": {
+            "@0x/assert": "^3.0.2",
+            "@0x/json-schemas": "^5.0.2",
+            "@0x/typescript-typings": "^5.0.1",
+            "@0x/utils": "^5.1.1",
+            "ethereum-types": "^3.0.0",
+            "ethereumjs-util": "^5.1.1",
+            "ethers": "~4.0.4",
+            "lodash": "^4.17.11"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "ethereum-types": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ethereum-types/-/ethereum-types-3.0.0.tgz",
+          "integrity": "sha512-jRSsiua+e4/89r7M3mqPcP1M2f3TgXxpVmWysy+7pEg2H4lwEQRWarbYfIpWp81NtxrcMQv5bMK+yR1MN4sDpg==",
+          "requires": {
+            "@types/node": "*",
+            "bignumber.js": "~9.0.0"
           }
         },
         "supports-color": {
@@ -158,19 +470,6 @@
           }
         }
       }
-    },
-    "@0x/contract-addresses": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@0x/contract-addresses/-/contract-addresses-2.3.3.tgz",
-      "integrity": "sha512-0sPrFfwICq4E9Mar3xMFBSrTCckP2AR0t+3daNfaUmh+Z5yteP6gdnTbuYVjgyEGlvC71K0ohhsqd4IzXN7O5Q==",
-      "requires": {
-        "lodash": "^4.17.11"
-      }
-    },
-    "@0x/contract-artifacts": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@0x/contract-artifacts/-/contract-artifacts-1.5.1.tgz",
-      "integrity": "sha512-LrGLpJ1mzKoNLNn6VchL5LlqA+Vu6HPbY/WLAkekazulKwrs4nSKiYqHG/snctSMEe64qp+V+zND6DbFqyHlgw=="
     },
     "@0x/json-schemas": {
       "version": "3.0.10",
@@ -184,87 +483,78 @@
       }
     },
     "@0x/order-utils": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@0x/order-utils/-/order-utils-8.1.1.tgz",
-      "integrity": "sha512-L82c5DK8yfoBY5OLn/XfqaqIKkHUpzSiflkbbPKx3GtaTzuiOWOV5bHdjfmV1mmj8DB2tU8EiziSCmWugliJ3Q==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@0x/order-utils/-/order-utils-10.0.1.tgz",
+      "integrity": "sha512-NZsDciNSQtn3ARPmWc+pNK62GK2miELKryhPwwQzqpQs7bi8RSCTf26TmTMtYeXUg3t0gVfhfRD8FGBur53N9A==",
       "requires": {
-        "@0x/abi-gen-wrappers": "^4.3.0",
-        "@0x/assert": "^2.0.10",
-        "@0x/base-contract": "^5.1.0",
-        "@0x/contract-addresses": "^2.3.3",
-        "@0x/contract-artifacts": "^1.5.1",
-        "@0x/json-schemas": "^3.0.10",
-        "@0x/types": "^2.2.2",
-        "@0x/typescript-typings": "^4.2.2",
-        "@0x/utils": "^4.3.3",
-        "@0x/web3-wrapper": "^6.0.6",
-        "@types/node": "*",
-        "bn.js": "^4.11.8",
-        "ethereum-types": "^2.1.2",
-        "ethereumjs-abi": "0.6.5",
+        "@0x/assert": "^3.0.2",
+        "@0x/contract-wrappers": "^13.2.0",
+        "@0x/json-schemas": "^5.0.2",
+        "@0x/utils": "^5.1.1",
+        "@0x/web3-wrapper": "^7.0.2",
         "ethereumjs-util": "^5.1.1",
         "ethers": "~4.0.4",
         "lodash": "^4.17.11"
       },
       "dependencies": {
         "@0x/assert": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/@0x/assert/-/assert-2.0.10.tgz",
-          "integrity": "sha512-tM3j5aZnJGTMr+7OAF61gmflrgEpUkp1LHNsnIx5VnVG+X7JzwV87O44PU9bALVQI1ufYvAUwhIkmK8jbR5Agw==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@0x/assert/-/assert-3.0.2.tgz",
+          "integrity": "sha512-kYRCP/eOoGX3S0zTXskIcy8jA0zxOm20BCDK7EImAQ8HvdmfZr8R6dqUm5UEBLd/JJ6jywR97Y+yCUiteIGg0g==",
           "requires": {
-            "@0x/json-schemas": "^3.0.10",
-            "@0x/typescript-typings": "^4.2.2",
-            "@0x/utils": "^4.3.3",
+            "@0x/json-schemas": "^5.0.2",
+            "@0x/typescript-typings": "^5.0.1",
+            "@0x/utils": "^5.1.1",
             "lodash": "^4.17.11",
             "valid-url": "^1.0.9"
           }
         },
         "@0x/json-schemas": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@0x/json-schemas/-/json-schemas-3.0.10.tgz",
-          "integrity": "sha512-RHYIaxf8C7GO/6VViD8zzRfs1B/i7P5vpCgPk8VR+aVDJXtceF9Nn72KiHeiHU9REUxMWgI3fzhYqTp5/CSbjA==",
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@0x/json-schemas/-/json-schemas-5.0.2.tgz",
+          "integrity": "sha512-2mwC42aWx6tvOCh58pRyYCSrmdajHdmfbDSCsII/8EOWRI6gYYenRMl/edVMnqKw7FH0QLsfWdx5GeP+jNoxDA==",
           "requires": {
-            "@0x/typescript-typings": "^4.2.2",
+            "@0x/typescript-typings": "^5.0.1",
             "@types/node": "*",
             "jsonschema": "^1.2.0",
             "lodash.values": "^4.3.0"
           }
         },
         "@0x/types": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/@0x/types/-/types-2.2.2.tgz",
-          "integrity": "sha512-25F3yjvdWGwiQ99CtFcvyL83PTR2fGQk7J1RzuGbqhu9LTdktjhbQl2/FUzPqbAnGXH47zh1ZZrrMSUVIW9SEA==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@0x/types/-/types-3.1.1.tgz",
+          "integrity": "sha512-+TQmzH+chWeDWpc+Lce3/q4X2UEHFfAwZcWrV7tEQ5EVAJvph7gpKawRW2XRsmHeQDSHBmiiBdSZ8Rc/OAjvlQ==",
           "requires": {
             "@types/node": "*",
-            "bignumber.js": "~8.0.2",
-            "ethereum-types": "^2.1.2"
+            "bignumber.js": "~9.0.0",
+            "ethereum-types": "^3.0.0"
           }
         },
         "@0x/typescript-typings": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/@0x/typescript-typings/-/typescript-typings-4.2.2.tgz",
-          "integrity": "sha512-KKioCi4rLOiC62DF8mqBgN639DdGcJllW7OSPi6gWG4w2JI0mvH6KpRA7wGS9fyIpupjpKTIvz6ktZBaG+DrWg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@0x/typescript-typings/-/typescript-typings-5.0.1.tgz",
+          "integrity": "sha512-zSA39URHkFnL16WD30VMa8wL8va0Khpx9APHffdPWpBOr9SUPdADtae5HO4iNCYvSgo3mrtPlKID2nIqREIHOQ==",
           "requires": {
             "@types/bn.js": "^4.11.0",
             "@types/react": "*",
-            "bignumber.js": "~8.0.2",
-            "ethereum-types": "^2.1.2",
+            "bignumber.js": "~9.0.0",
+            "ethereum-types": "^3.0.0",
             "popper.js": "1.14.3"
           }
         },
         "@0x/utils": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/@0x/utils/-/utils-4.3.3.tgz",
-          "integrity": "sha512-gAFKM8kV5I4A6mpn4+nl9pkstyDiFfQBGz4JBI6ES7s/HRetenVurFN8v1EpEF4N/SOtTzqhGerDUVVtrM3YSQ==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@0x/utils/-/utils-5.1.1.tgz",
+          "integrity": "sha512-DRNKtAqZR0vFA1XdUhBwaIz2qEjWS1xqdvzQl/Dn8OLJH+1sxb+1UmtG6fOlbu7pTLbF+CWoaYf2+pvQfcF//g==",
           "requires": {
-            "@0x/types": "^2.2.2",
-            "@0x/typescript-typings": "^4.2.2",
+            "@0x/types": "^3.1.1",
+            "@0x/typescript-typings": "^5.0.1",
             "@types/node": "*",
             "abortcontroller-polyfill": "^1.1.9",
-            "bignumber.js": "~8.0.2",
+            "bignumber.js": "~9.0.0",
             "chalk": "^2.3.0",
             "detect-node": "2.0.3",
-            "ethereum-types": "^2.1.2",
+            "ethereum-types": "^3.0.0",
             "ethereumjs-util": "^5.1.1",
             "ethers": "~4.0.4",
             "isomorphic-fetch": "2.2.1",
@@ -273,15 +563,15 @@
           }
         },
         "@0x/web3-wrapper": {
-          "version": "6.0.6",
-          "resolved": "https://registry.npmjs.org/@0x/web3-wrapper/-/web3-wrapper-6.0.6.tgz",
-          "integrity": "sha512-cmDHgYnPGNs6ItMw5h+hLe3Cvqaj6V1RY14ZMCc87L7PrwUFQLnrmSfKcsjaqsNDEmbjLf2dNL25DVu6FN/uyw==",
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/@0x/web3-wrapper/-/web3-wrapper-7.0.2.tgz",
+          "integrity": "sha512-kSmrg0E0ZmuNKTKmanxHlRUO5dom8Wr2eDmgG+NZcuWY3EJKIkuxFsz6KRUfoYbVOVT22ZQZazzZIGwoz/LObg==",
           "requires": {
-            "@0x/assert": "^2.0.10",
-            "@0x/json-schemas": "^3.0.10",
-            "@0x/typescript-typings": "^4.2.2",
-            "@0x/utils": "^4.3.3",
-            "ethereum-types": "^2.1.2",
+            "@0x/assert": "^3.0.2",
+            "@0x/json-schemas": "^5.0.2",
+            "@0x/typescript-typings": "^5.0.1",
+            "@0x/utils": "^5.1.1",
+            "ethereum-types": "^3.0.0",
             "ethereumjs-util": "^5.1.1",
             "ethers": "~4.0.4",
             "lodash": "^4.17.11"
@@ -295,11 +585,6 @@
             "color-convert": "^1.9.0"
           }
         },
-        "bignumber.js": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.2.tgz",
-          "integrity": "sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw=="
-        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -311,12 +596,12 @@
           }
         },
         "ethereum-types": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ethereum-types/-/ethereum-types-2.1.2.tgz",
-          "integrity": "sha512-JsQnroPOsZ81yN75HVzvobosSxjr/59oEdYnydTgnV13Fg9PwS078CtPyBzARXequBl2Hnz4h7f3VF64u8P01A==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ethereum-types/-/ethereum-types-3.0.0.tgz",
+          "integrity": "sha512-jRSsiua+e4/89r7M3mqPcP1M2f3TgXxpVmWysy+7pEg2H4lwEQRWarbYfIpWp81NtxrcMQv5bMK+yR1MN4sDpg==",
           "requires": {
             "@types/node": "*",
-            "bignumber.js": "~8.0.2"
+            "bignumber.js": "~9.0.0"
           }
         },
         "supports-color": {
@@ -3515,6 +3800,11 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
+    "core-js-pure": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.1.tgz",
+      "integrity": "sha512-yKiUdvQWq66xUc408duxUCxFHuDfz5trF5V4xnQzb8C7P/5v2gFUdyNWQoevyAeGYB1hl1X/pzGZ20R3WxZQBA=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4020,6 +4310,41 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
         "iconv-lite": "~0.4.13"
+      }
+    },
+    "encoding-down": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
+      "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
+      "requires": {
+        "abstract-leveldown": "^5.0.0",
+        "inherits": "^2.0.3",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
+        "level-codec": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
+          "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q=="
+        },
+        "level-errors": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+          "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+          "requires": {
+            "errno": "~0.1.1"
+          }
+        }
       }
     },
     "end-of-stream": {
@@ -4662,6 +4987,36 @@
         "through2": "^2.0.3"
       }
     },
+    "ethashjs": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ethashjs/-/ethashjs-0.0.7.tgz",
+      "integrity": "sha1-ML/kGWcmaQoMWdO4Jy5w1NDDS64=",
+      "requires": {
+        "async": "^1.4.2",
+        "buffer-xor": "^1.0.3",
+        "ethereumjs-util": "^4.0.1",
+        "miller-rabin": "^4.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "ethereumjs-util": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+          "requires": {
+            "bn.js": "^4.8.0",
+            "create-hash": "^1.1.2",
+            "keccakjs": "^0.2.0",
+            "rlp": "^2.0.0",
+            "secp256k1": "^3.0.1"
+          }
+        }
+      }
+    },
     "ethereum-common": {
       "version": "0.0.18",
       "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
@@ -4680,29 +5035,6 @@
           "version": "8.0.2",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.2.tgz",
           "integrity": "sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw=="
-        }
-      }
-    },
-    "ethereumjs-abi": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
-      "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
-      "requires": {
-        "bn.js": "^4.10.0",
-        "ethereumjs-util": "^4.3.0"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
-          "requires": {
-            "bn.js": "^4.8.0",
-            "create-hash": "^1.1.2",
-            "keccakjs": "^0.2.0",
-            "rlp": "^2.0.0",
-            "secp256k1": "^3.0.1"
-          }
         }
       }
     },
@@ -4732,6 +5064,120 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
           "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+        }
+      }
+    },
+    "ethereumjs-blockchain": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.3.tgz",
+      "integrity": "sha512-0nJWbyA+Gu0ZKZr/cywMtB/77aS/4lOVsIKbgUN2sFQYscXO5rPbUfrEe7G2Zhjp86/a0VqLllemDSTHvx3vZA==",
+      "requires": {
+        "async": "^2.6.1",
+        "ethashjs": "~0.0.7",
+        "ethereumjs-block": "~2.2.2",
+        "ethereumjs-common": "^1.5.0",
+        "ethereumjs-util": "~6.1.0",
+        "flow-stoplight": "^1.0.0",
+        "level-mem": "^3.0.1",
+        "lru-cache": "^5.1.1",
+        "rlp": "^2.2.2",
+        "semaphore": "^1.1.0"
+      },
+      "dependencies": {
+        "ethereumjs-block": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.2.2.tgz",
+          "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
+          "requires": {
+            "async": "^2.0.1",
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-tx": "^2.1.1",
+            "ethereumjs-util": "^5.0.0",
+            "merkle-patricia-tree": "^2.1.2"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "ethereumjs-common": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
+          "integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ=="
+        },
+        "ethereumjs-tx": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+          "requires": {
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+          "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "0.1.6",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "rlp": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+          "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+          "requires": {
+            "bn.js": "^4.11.1"
+          }
+        }
+      }
+    },
+    "ethereumjs-blockstream": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-blockstream/-/ethereumjs-blockstream-7.0.0.tgz",
+      "integrity": "sha512-lt3uLKDEfNHEqqnl/+W0aC7xp2y7JEsgZsJMZ958CNrYIJH9tZ7oa8npwV2M0KhGlfzmJsyJIpvV/Lvb2mh0tA==",
+      "requires": {
+        "immutable": "3.8.2",
+        "source-map-support": "0.5.6",
+        "uuid": "3.2.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-support": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+          "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         }
       }
     },
@@ -5186,8 +5632,7 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -5262,6 +5707,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
+    },
+    "flow-stoplight": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flow-stoplight/-/flow-stoplight-1.0.0.tgz",
+      "integrity": "sha1-SiksW8/4s5+mzAyxqFPYbyfu/3s="
     },
     "fn-name": {
       "version": "2.0.1",
@@ -17668,6 +18118,11 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
       "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
     },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+    },
     "import-fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -19568,6 +20023,95 @@
         }
       }
     },
+    "level-mem": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-3.0.1.tgz",
+      "integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
+      "requires": {
+        "level-packager": "~4.0.0",
+        "memdown": "~3.0.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
+        "memdown": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
+          "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
+          "requires": {
+            "abstract-leveldown": "~5.0.0",
+            "functional-red-black-tree": "~1.0.1",
+            "immediate": "~3.2.3",
+            "inherits": "~2.0.1",
+            "ltgt": "~2.2.0",
+            "safe-buffer": "~5.1.1"
+          }
+        }
+      }
+    },
+    "level-packager": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
+      "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
+      "requires": {
+        "encoding-down": "~5.0.0",
+        "levelup": "^3.0.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
+        "deferred-leveldown": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
+          "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
+          "requires": {
+            "abstract-leveldown": "~5.0.0",
+            "inherits": "^2.0.3"
+          }
+        },
+        "level-errors": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+          "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+          "requires": {
+            "errno": "~0.1.1"
+          }
+        },
+        "level-iterator-stream": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
+          "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.3.6",
+            "xtend": "^4.0.0"
+          }
+        },
+        "levelup": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
+          "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
+          "requires": {
+            "deferred-leveldown": "~4.0.0",
+            "level-errors": "~2.0.0",
+            "level-iterator-stream": "~3.0.0",
+            "xtend": "~4.0.0"
+          }
+        }
+      }
+    },
     "level-ws": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
@@ -19999,6 +20543,14 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
     "ltgt": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
@@ -20148,6 +20700,15 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
+      }
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime-db": {
@@ -21891,9 +22452,9 @@
       }
     },
     "sha3": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.3.tgz",
-      "integrity": "sha512-sOWDZi8cDBRkLfWOw18wvJyNblXDHzwMGnRWut8zNNeIeLnmMRO17bjpLc7OzMuj1ASUgx2IyohzUCAl+Kx5vA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.6.tgz",
+      "integrity": "sha512-KgLGmJGrmNB4JWVsAV11Yk6KbvsAiygWJc7t5IebWva/0NukNrjJqhtKhzy3Eiv2AKuGvhZZt7dt1mDo7HkoiQ==",
       "requires": {
         "nan": "2.13.2"
       },
@@ -23341,9 +23902,7 @@
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prettier": "1.19.1"
   },
   "dependencies": {
-    "@0x/order-utils": "8.1.1",
+    "@0x/order-utils": "10.0.1",
     "@0x/subproviders": "4.1.0",
     "@0x/utils": "4.3.3",
     "@0x/web3-wrapper": "6.0.7",

--- a/src/index/fills/__snapshots__/create-document.test.js.snap
+++ b/src/index/fills/__snapshots__/create-document.test.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`assets should include bridgeAddress property when asset is bridged 1`] = `
+Array [
+  Object {
+    "bridgeAddress": "0x58b7b96e170e46c07d02fac903cd1b3356b7549f",
+    "tokenAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
+  },
+  Object {
+    "bridgeAddress": "0x58b7b96e170e46c07d02fac903cd1b3356b7549f",
+    "tokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+  },
+]
+`;
+
 exports[`should create Elasticsearch document for fill 1`] = `
 Object {
   "assets": Array [
@@ -25,17 +38,4 @@ Object {
   "transactionHash": "0x36a35ae64def8beab677435be4762bf63977000172d47096230a94922383c856",
   "value": 658.8957691929245,
 }
-`;
-
-exports[`should include asset.bridgeAddress property when asset is bridged 1`] = `
-Array [
-  Object {
-    "bridgeAddress": "0x58b7b96e170e46c07d02fac903cd1b3356b7549f",
-    "tokenAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
-  },
-  Object {
-    "bridgeAddress": "0x58b7b96e170e46c07d02fac903cd1b3356b7549f",
-    "tokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-  },
-]
 `;

--- a/src/index/fills/__snapshots__/create-document.test.js.snap
+++ b/src/index/fills/__snapshots__/create-document.test.js.snap
@@ -4,9 +4,11 @@ exports[`should create Elasticsearch document for fill 1`] = `
 Object {
   "assets": Array [
     Object {
+      "bridgeAddress": undefined,
       "tokenAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
     },
     Object {
+      "bridgeAddress": undefined,
       "tokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
     },
   ],
@@ -23,4 +25,17 @@ Object {
   "transactionHash": "0x36a35ae64def8beab677435be4762bf63977000172d47096230a94922383c856",
   "value": 658.8957691929245,
 }
+`;
+
+exports[`should include asset.bridgeAddress property when asset is bridged 1`] = `
+Array [
+  Object {
+    "bridgeAddress": "0x58b7b96e170e46c07d02fac903cd1b3356b7549f",
+    "tokenAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
+  },
+  Object {
+    "bridgeAddress": "0x58b7b96e170e46c07d02fac903cd1b3356b7549f",
+    "tokenAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+  },
+]
 `;

--- a/src/index/fills/create-document.js
+++ b/src/index/fills/create-document.js
@@ -4,7 +4,10 @@ const createDocument = fill => {
   const value = _.get(fill, 'conversions.USD.amount');
 
   return {
-    assets: fill.assets.map(asset => ({ tokenAddress: asset.tokenAddress })),
+    assets: fill.assets.map(asset => ({
+      bridgeAddress: asset.bridgeAddress,
+      tokenAddress: asset.tokenAddress,
+    })),
     date: fill.date,
     fees: fill.fees.map(fee => ({ tokenAddress: fee.tokenAddress })),
     feeRecipient: fill.feeRecipient,

--- a/src/index/fills/create-document.test.js
+++ b/src/index/fills/create-document.test.js
@@ -19,7 +19,7 @@ it('should exclude value property when fill is unmeasured', () => {
   expect(doc.value).toBeUndefined();
 });
 
-it('should include asset.bridgeAddress property when asset is bridged', () => {
+it('assets should include bridgeAddress property when asset is bridged', () => {
   const fill = {
     ...V2_FILL,
     assets: V2_FILL.assets.map(asset => ({

--- a/src/index/fills/create-document.test.js
+++ b/src/index/fills/create-document.test.js
@@ -18,3 +18,16 @@ it('should exclude value property when fill is unmeasured', () => {
 
   expect(doc.value).toBeUndefined();
 });
+
+it('should include asset.bridgeAddress property when asset is bridged', () => {
+  const fill = {
+    ...V2_FILL,
+    assets: V2_FILL.assets.map(asset => ({
+      ...asset,
+      bridgeAddress: '0x58b7b96e170e46c07d02fac903cd1b3356b7549f',
+    })),
+  };
+  const doc = createDocument(fill);
+
+  expect(doc.assets).toMatchSnapshot();
+});

--- a/src/jobs/create-fills/extract-fees-from-event-args.test.js
+++ b/src/jobs/create-fills/extract-fees-from-event-args.test.js
@@ -42,6 +42,36 @@ describe('extractFeesFromEventArgs', () => {
     ]);
   });
 
+  it('should extract bridge fees for v3.0 fill event', () => {
+    const args = {
+      ...V3_EVENT.data.args,
+      makerFeeAssetData:
+        '0xdc1600f3000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000058b7b96e170e46c07d02fac903cd1b3356b7549f000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000400000000000000000000000006b175474e89094c44da98b954eedeac495271d0f00000000000000000000000000000000000000000000000000000000000a5a2f',
+    };
+    const protocolVersion = 3;
+    const fees = extractFeesFromEventArgs(args, protocolVersion);
+
+    expect(fees).toEqual([
+      {
+        amount: { token: 500000000000 },
+        bridgeAddress: '0x58b7b96e170e46c07d02fac903cd1b3356b7549f',
+        bridgeData:
+          '0x0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f00000000000000000000000000000000000000000000000000000000000a5a2f',
+        tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+        tokenType: 0,
+        traderType: 0,
+      },
+      {
+        amount: {
+          token: 300000000,
+        },
+        tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+        tokenType: 0,
+        traderType: 1,
+      },
+    ]);
+  });
+
   it('should return undefined for v3 fill event when makerFeeAssetData is corrupt', () => {
     const protocolVersion = 3;
     const eventArgs = { ...V3_EVENT.data.args, makerFeeAssetData: 'fubar' };

--- a/src/jobs/create-fills/extract-fees-from-event-args.test.js
+++ b/src/jobs/create-fills/extract-fees-from-event-args.test.js
@@ -42,7 +42,7 @@ describe('extractFeesFromEventArgs', () => {
     ]);
   });
 
-  it('should extract bridge fees for v3.0 fill event', () => {
+  it('should extract bridged fees for v3.0 fill event', () => {
     const args = {
       ...V3_EVENT.data.args,
       makerFeeAssetData:

--- a/src/jobs/create-fills/get-assets.test.js
+++ b/src/jobs/create-fills/get-assets.test.js
@@ -161,6 +161,47 @@ it('should get assets for V2 event with multi-asset data', () => {
   ]);
 });
 
+it('should get assets for V2 event with bridged ERC20 asset data', () => {
+  const eventArgs = {
+    makerAddress: '0x9193ed9cbf94d109667c3d5659caffe21b4197bc',
+    feeRecipientAddress: '0x0000000000000000000000000000000000000000',
+    takerAddress: '0xdf1bc6498338135de5ffdbcb98817d81e2665912',
+    senderAddress: '0xdf1bc6498338135de5ffdbcb98817d81e2665912',
+    makerAssetFilledAmount: 7597171425070027,
+    takerAssetFilledAmount: 46810278916603824.0,
+    makerFeePaid: 0,
+    takerFeePaid: 0,
+    orderHash:
+      '0xc9a69b17a479155016a724a250a6093903bcaafa318e757eab2c7fc6d5ca3edd',
+    makerAssetData:
+      '0xdc1600f3000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000058b7b96e170e46c07d02fac903cd1b3356b7549f000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000400000000000000000000000006b175474e89094c44da98b954eedeac495271d0f00000000000000000000000000000000000000000000000000000000000a5a2f',
+    takerAssetData:
+      '0xf47261b000000000000000000000000053b04999c1ff2d77fcdde98935bb936a67209e4c',
+  };
+  const assets = getAssets(eventArgs, 2);
+
+  expect(assets).toEqual([
+    {
+      actor: 0,
+      amount: 7597171425070027,
+      bridgeAddress: '0x58b7b96e170e46c07d02fac903cd1b3356b7549f',
+      bridgeData:
+        '0x0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f00000000000000000000000000000000000000000000000000000000000a5a2f',
+      bridged: true,
+      tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+      tokenResolved: false,
+      tokenType: 0,
+    },
+    {
+      actor: 1,
+      amount: 46810278916603820,
+      tokenAddress: '0x53b04999c1ff2d77fcdde98935bb936a67209e4c',
+      tokenResolved: false,
+      tokenType: 0,
+    },
+  ]);
+});
+
 it('should return undefined when one of the assets data is corrupt', () => {
   const eventArgs = {
     makerAddress: '0x9193ed9cbf94d109667c3d5659caffe21b4197bc',

--- a/src/jobs/create-fills/get-assets.test.js
+++ b/src/jobs/create-fills/get-assets.test.js
@@ -187,7 +187,6 @@ it('should get assets for V2 event with bridged ERC20 asset data', () => {
       bridgeAddress: '0x58b7b96e170e46c07d02fac903cd1b3356b7549f',
       bridgeData:
         '0x0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f00000000000000000000000000000000000000000000000000000000000a5a2f',
-      bridged: true,
       tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
       tokenResolved: false,
       tokenType: 0,

--- a/src/jobs/create-fills/parse-asset-data.js
+++ b/src/jobs/create-fills/parse-asset-data.js
@@ -17,34 +17,33 @@ const decodeAssetData = assetData => {
   }
 };
 
-const createAsset = (singleAssetData, amount) => {
-  const simpleAsset = {
+const createAsset = (assetData, amount) => {
+  const baseAsset = {
     amount,
-    tokenAddress: singleAssetData.tokenAddress,
+    tokenAddress: assetData.tokenAddress,
   };
 
-  if (isERC20AssetData(singleAssetData)) {
+  if (isERC20AssetData(assetData)) {
     return {
-      ...simpleAsset,
+      ...baseAsset,
       tokenType: TOKEN_TYPE.ERC20,
     };
   }
 
-  if (isERC721AssetData(singleAssetData)) {
+  if (isERC721AssetData(assetData)) {
     return {
-      ...simpleAsset,
-      tokenId: singleAssetData.tokenId.toNumber(),
+      ...baseAsset,
+      tokenId: assetData.tokenId.toNumber(),
       tokenType: TOKEN_TYPE.ERC721,
     };
   }
 
-  if (isERC20BridgeAssetData(singleAssetData)) {
+  if (isERC20BridgeAssetData(assetData)) {
     return {
-      ...simpleAsset,
-      bridged: true,
-      bridgeAddress: singleAssetData.bridgeAddress,
-      bridgeData: singleAssetData.bridgeData,
-      tokenAddress: singleAssetData.tokenAddress,
+      ...baseAsset,
+      bridgeAddress: assetData.bridgeAddress,
+      bridgeData: assetData.bridgeData,
+      tokenAddress: assetData.tokenAddress,
       tokenType: TOKEN_TYPE.ERC20,
     };
   }

--- a/src/jobs/create-fills/parse-asset-data.js
+++ b/src/jobs/create-fills/parse-asset-data.js
@@ -1,12 +1,13 @@
 const { assetDataUtils } = require('@0x/order-utils');
 const { TOKEN_TYPE } = require('../../constants');
 
-const {
-  decodeAssetDataOrThrow,
-  isERC20AssetData,
-  isERC721AssetData,
-  isMultiAssetData,
-} = assetDataUtils;
+const { decodeAssetDataOrThrow } = assetDataUtils;
+
+const isERC20AssetData = assetData => assetData.assetProxyId === '0xf47261b0';
+const isERC721AssetData = assetData => assetData.assetProxyId === '0x02571792';
+const isMultiAssetData = assetData => assetData.assetProxyId === '0x94cfcdd7';
+const isERC20BridgeAssetData = assetData =>
+  assetData.assetProxyId === '0xdc1600f3';
 
 const decodeAssetData = assetData => {
   try {
@@ -34,6 +35,17 @@ const createAsset = (singleAssetData, amount) => {
       ...simpleAsset,
       tokenId: singleAssetData.tokenId.toNumber(),
       tokenType: TOKEN_TYPE.ERC721,
+    };
+  }
+
+  if (isERC20BridgeAssetData(singleAssetData)) {
+    return {
+      ...simpleAsset,
+      bridged: true,
+      bridgeAddress: singleAssetData.bridgeAddress,
+      bridgeData: singleAssetData.bridgeData,
+      tokenAddress: singleAssetData.tokenAddress,
+      tokenType: TOKEN_TYPE.ERC20,
     };
   }
 
@@ -68,7 +80,11 @@ const parseAssetData = (encodedData, amount) => {
   }
 
   // When the asset data represents a single asset we can just return a single item array.
-  if (isERC20AssetData(assetData) || isERC721AssetData(assetData)) {
+  if (
+    isERC20AssetData(assetData) ||
+    isERC721AssetData(assetData) ||
+    isERC20BridgeAssetData(assetData)
+  ) {
     return [createAsset(assetData, amount)];
   }
 

--- a/src/model/fill.js
+++ b/src/model/fill.js
@@ -38,6 +38,8 @@ const createModel = () => {
     fees: [
       {
         amount: { token: Number, USD: Number },
+        bridgeAddress: String,
+        bridgeData: String,
         tokenAddress: String,
         tokenId: Number,
         traderType: Number,

--- a/src/model/fill.js
+++ b/src/model/fill.js
@@ -10,6 +10,8 @@ const createModel = () => {
       {
         actor: Number,
         amount: Number,
+        bridgeAddress: String,
+        bridgeData: String,
         price: {
           USD: Number,
         },


### PR DESCRIPTION
This PR introduces support for bridged ERC-20 assets by ensuring that:

- Bridged assets are parsed
- Bridge address and data are stored against bridged assets/fees
- Bridge address is indexed in Elasticsearch