### PR TITLE
Add trader count stats to relayer metrics model

### DIFF
--- a/src/model/relayer-metric.js
+++ b/src/model/relayer-metric.js
@@ -1,6 +1,9 @@
 const mongoose = require('mongoose');
 
 const metricShape = {
+  activeMakers: Number,
+  activeTakers: Number,
+  activeTraders: Number,
   date: { index: true, type: Date },
   fees: {
     USD: Number,


### PR DESCRIPTION
This PR updates the relayer metrics caching job to store active trader, active maker, and active taker counts.