### PR TITLE
Fix calculation of trade stats for non-relayer fills

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -25,9 +25,9 @@ module.exports = {
     poolSize: process.env.POOL_SIZE || 30,
   },
   elasticsearch: {
-    password: process.env.ELASTIC_SEARCH_PASSWORD,
+    password: _.get(process.env, 'ELASTIC_SEARCH_PASSWORD', null),
     url: process.env.ELASTIC_SEARCH_URL,
-    username: process.env.ELASTIC_SEARCH_USERNAME,
+    username: _.get(process.env, 'ELASTIC_SEARCH_USERNAME', null),
   },
   ercDex: {
     feeRecipientPollingInterval: ms('1 minute'),

--- a/src/index/fills/create-document.test.js
+++ b/src/index/fills/create-document.test.js
@@ -60,3 +60,25 @@ it('should index protocol fee for V3 fills', () => {
   expect(doc.protocolFeeETH).toBe(1500000000150000);
   expect(doc.protocolFeeUSD).toBe(0.338445000033844);
 });
+
+it('should set tradeVolume and tradeCountContribution to zero when relayerId is null', () => {
+  const fill = {
+    ...V2_FILL,
+    relayerId: null,
+  };
+  const doc = createDocument(fill);
+
+  expect(doc.tradeVolume).toBe(0);
+  expect(doc.tradeCountContribution).toBe(0);
+});
+
+it('should set tradeVolume and tradeCountContribution to zero when relayerId is undefined', () => {
+  const fill = {
+    ...V2_FILL,
+    relayerId: undefined,
+  };
+  const doc = createDocument(fill);
+
+  expect(doc.tradeVolume).toBe(0);
+  expect(doc.tradeCountContribution).toBe(0);
+});


### PR DESCRIPTION
This PR fixes the calculation of tradeCountContribution and tradeVolume stats on the fills index by ensuring that non-relayer fills have their values set to zero.