### PR TITLE
Refactor create new tokens util

### DIFF
--- a/src/consumers/create-token.test.js
+++ b/src/consumers/create-token.test.js
@@ -70,7 +70,7 @@ describe('consumers.createToken', () => {
 
   it('should not create token if it already exists', async () => {
     const { Token } = getModels();
-    await Token.create({ address: '0xabc', tokenType: 0 });
+    await Token.create({ address: '0xabc', type: 0 });
     const newToken = await createToken(
       {
         data: { tokenAddress: '0xabc', tokenType: 0 },

--- a/src/jobs/create-fills/create-fill.test.js
+++ b/src/jobs/create-fills/create-fill.test.js
@@ -143,10 +143,12 @@ describe('createFill', () => {
           {
             address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
             tradeCountContribution: 1,
+            type: 0,
           },
           {
             address: '0xd0a4b8946cb52f0661273bfbc6fd0e0c75fc6433',
             tradeCountContribution: 1,
+            type: 0,
           },
         ],
       },
@@ -155,43 +157,43 @@ describe('createFill', () => {
       },
     );
 
-    // Ensure job for creating taker token is published when token doesn't already exist
-    expect(publishJob).toHaveBeenCalledWith(
-      'token-processing',
-      'create-token',
-      {
-        tokenAddress: '0xd0a4b8946cb52f0661273bfbc6fd0e0c75fc6433',
-        tokenType: 0,
-      },
-      {
-        jobId: `create-token-0xd0a4b8946cb52f0661273bfbc6fd0e0c75fc6433`,
-      },
-    );
+    /*
+     * Ensure all the associated tokens are created when they don't already exist
+     */
+    const tokens = await getModel('Token')
+      .find()
+      .lean();
 
-    // Ensure job for creating maker token is published when token doesn't already exist
-    expect(publishJob).toHaveBeenCalledWith(
-      'token-processing',
-      'create-token',
-      {
-        tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-        tokenType: 0,
-      },
-      {
-        jobId: `create-token-0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2`,
-      },
-    );
-
-    // Ensure job for creating ZRX token is published when token doesn't already exist
-    expect(publishJob).toHaveBeenCalledWith(
-      'token-processing',
-      'create-token',
-      {
-        tokenAddress: '0xe41d2489571d322189246dafa5ebde1f4699f498',
-        tokenType: 0,
-      },
-      {
-        jobId: `create-token-0xe41d2489571d322189246dafa5ebde1f4699f498`,
-      },
+    expect(tokens).toEqual(
+      expect.arrayContaining([
+        {
+          __v: 0,
+          _id: expect.anything(),
+          address: '0xd0a4b8946cb52f0661273bfbc6fd0e0c75fc6433',
+          createdAt: expect.anything(),
+          resolved: false,
+          type: 0,
+          updatedAt: expect.anything(),
+        },
+        {
+          __v: 0,
+          _id: expect.anything(),
+          address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          createdAt: expect.anything(),
+          resolved: false,
+          type: 0,
+          updatedAt: expect.anything(),
+        },
+        {
+          __v: 0,
+          _id: expect.anything(),
+          address: '0xe41d2489571d322189246dafa5ebde1f4699f498',
+          createdAt: expect.anything(),
+          resolved: false,
+          type: 0,
+          updatedAt: expect.anything(),
+        },
+      ]),
     );
   }, 60000);
 

--- a/src/model/token.js
+++ b/src/model/token.js
@@ -4,17 +4,17 @@ const { Schema } = mongoose;
 
 const schema = Schema(
   {
-    address: String,
+    address: { lowercase: true, required: true, trim: true, type: String },
     circulatingSupply: Number,
     decimals: Number,
     imageUrl: { type: String, trim: true },
     name: String,
-    resolved: Boolean,
+    resolved: { default: false, type: Boolean },
     symbol: String,
     totalSupply: Number,
-    type: Number,
+    type: { required: true, type: Number },
   },
-  { timestamps: true },
+  { strict: true, timestamps: true },
 );
 
 schema.index({ address: 1 }, { unique: true });

--- a/src/tokens/create-new-tokens.test.js
+++ b/src/tokens/create-new-tokens.test.js
@@ -1,21 +1,39 @@
 const { publishJob } = require('../queues');
 const createNewTokens = require('./create-new-tokens');
 const getExistingTokens = require('./get-existing-tokens');
+const testUtils = require('../test-utils');
+const Token = require('../model/token');
 
 jest.mock('../queues');
 jest.mock('./get-existing-tokens');
 
+beforeAll(async () => {
+  await testUtils.setupDb();
+}, 30000);
+
 beforeEach(() => {
-  jest.resetAllMocks();
+  jest.clearAllMocks();
 });
 
-it('should publish no jobs when no tokens specified', async () => {
+afterEach(async () => {
+  await testUtils.resetDb();
+}, 30000);
+
+afterAll(async () => {
+  await testUtils.tearDownDb();
+}, 30000);
+
+it('should create no tokens when no tokens specified', async () => {
   await createNewTokens([]);
 
   expect(publishJob).toHaveBeenCalledTimes(0);
+
+  const tokens = await Token.find().lean();
+
+  expect(tokens).toHaveLength(0);
 });
 
-it('should publish jobs for tokens when they are all new', async () => {
+it('should create all tokens when they are all new', async () => {
   getExistingTokens.mockResolvedValueOnce([]);
 
   await createNewTokens([
@@ -24,23 +42,48 @@ it('should publish jobs for tokens when they are all new', async () => {
   ]);
 
   expect(publishJob).toHaveBeenCalledTimes(2);
-  expect(publishJob).toHaveBeenNthCalledWith(
-    1,
+  expect(publishJob).toHaveBeenCalledWith(
     'token-processing',
-    'create-token',
+    'fetch-token-metadata',
     { tokenAddress: '0x123', tokenType: 0 },
-    { jobId: 'create-token-0x123' },
+    { delay: 30000, jobId: 'fetch-token-metadata-0x123' },
   );
-  expect(publishJob).toHaveBeenNthCalledWith(
-    2,
+  expect(publishJob).toHaveBeenCalledWith(
     'token-processing',
-    'create-token',
+    'fetch-token-metadata',
     { tokenAddress: '0x567', tokenType: 1 },
-    { jobId: 'create-token-0x567' },
+    { delay: 30000, jobId: 'fetch-token-metadata-0x567' },
+  );
+
+  const tokens = await Token.find().lean();
+
+  expect(tokens).toHaveLength(2);
+  expect(tokens).toEqual(
+    expect.arrayContaining([
+      {
+        _id: expect.anything(),
+        __v: 0,
+        address: '0x123',
+        createdAt: expect.anything(),
+        resolved: false,
+        type: 0,
+        updatedAt: expect.anything(),
+      },
+      {
+        _id: expect.anything(),
+        __v: 0,
+        address: '0x567',
+        createdAt: expect.anything(),
+        resolved: false,
+        type: 1,
+        updatedAt: expect.anything(),
+      },
+    ]),
   );
 });
 
-it('should not publish jobs when all tokens exist', async () => {
+it('should not create any new tokens when all tokens exist', async () => {
+  // TODO: Get rid of this mock
   getExistingTokens.mockResolvedValueOnce(['0x123', '0x567']);
 
   await createNewTokens([
@@ -49,9 +92,13 @@ it('should not publish jobs when all tokens exist', async () => {
   ]);
 
   expect(publishJob).toHaveBeenCalledTimes(0);
+
+  const tokens = await Token.find().lean();
+  expect(tokens).toHaveLength(0);
 });
 
-it('should publish some jobs when some tokens already exist', async () => {
+it('should create new tokens when some tokens already exist', async () => {
+  // TODO: Get rid of this mock
   getExistingTokens.mockResolvedValueOnce(['0x567']);
 
   await createNewTokens([
@@ -60,11 +107,27 @@ it('should publish some jobs when some tokens already exist', async () => {
   ]);
 
   expect(publishJob).toHaveBeenCalledTimes(1);
-  expect(publishJob).toHaveBeenNthCalledWith(
-    1,
+  expect(publishJob).toHaveBeenCalledWith(
     'token-processing',
-    'create-token',
+    'fetch-token-metadata',
     { tokenAddress: '0x123', tokenType: 0 },
-    { jobId: 'create-token-0x123' },
+    { delay: 30000, jobId: 'fetch-token-metadata-0x123' },
+  );
+
+  const tokens = await Token.find().lean();
+
+  expect(tokens).toHaveLength(1);
+  expect(tokens).toEqual(
+    expect.arrayContaining([
+      {
+        _id: expect.anything(),
+        __v: 0,
+        address: '0x123',
+        createdAt: expect.anything(),
+        resolved: false,
+        type: 0,
+        updatedAt: expect.anything(),
+      },
+    ]),
   );
 });


### PR DESCRIPTION
This PR refactors the `createNewTokens` util to create tokens immediately and then publish jobs for the fetching of their metadata. The tokens were previously being created via a separate job, however the indirection is unneccesary.